### PR TITLE
Updated module path with full URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module donut
+module github.com/flavioribeiro/donut
 
 go 1.19
 


### PR DESCRIPTION
Intended to resolve error during install:

go: github.com/flavioribeiro/donut@latest: github.com/flavioribeiro/donut@v0.0.0-20221104204520-94e6205b2e5f: parsing go.mod:
	module declares its path as: donut
	        but was required as: github.com/flavioribeiro/donut